### PR TITLE
Suppress jQuery link in example.html

### DIFF
--- a/example.html
+++ b/example.html
@@ -4,7 +4,6 @@
         <meta charset="utf-8">
         <title>SVG Tree Drawer Example</title>
         <meta property="og:image" content="http://westonruter.github.com/svg-tree-drawer/example.png" />
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
         <script src="svg-tree-drawer.js"></script>
         <style>
         svg text {


### PR DESCRIPTION
As this example doesn't seem to use it, and neither does `svg-tree-drawer.js`.
